### PR TITLE
check for NULL when parsing strings

### DIFF
--- a/src/fs.c
+++ b/src/fs.c
@@ -58,7 +58,7 @@ static int duv_string_to_flags(duk_context *ctx, const char* string) {
   bool read = false;
   bool write = false;
   int flags = 0;
-  while (string) {
+  while (string && *string != NULL) {
     switch (string[0]) {
       case 'r': read = true; break;
       case 'w': write = true; flags |= O_TRUNC | O_CREAT; break;

--- a/src/fs.c
+++ b/src/fs.c
@@ -58,7 +58,7 @@ static int duv_string_to_flags(duk_context *ctx, const char* string) {
   bool read = false;
   bool write = false;
   int flags = 0;
-  while (string && *string != NULL) {
+  while (string && string[0] != NULL) {
     switch (string[0]) {
       case 'r': read = true; break;
       case 'w': write = true; flags |= O_TRUNC | O_CREAT; break;


### PR DESCRIPTION
to reproduce the issue:

```
$ build/duklub repl.js
```

```js
fd = uv.fs_open('./b.js', 'r', 0644);
uv.fs_read(fd, 1024, 0).toString();
```

before the change, an error trying to parse an empty string (NULL), after the change, expected behavior.