### PR TITLE
fix duv_mod_compile

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -369,15 +369,19 @@ static duk_ret_t duv_mod_compile(duk_context *ctx) {
   });
   duk_to_string(ctx, 0);
 
+  duk_push_this(ctx);
+  duk_get_prop_string(ctx, -1, "id");
+
   // Wrap the code
   duk_push_string(ctx, "function(){var module=this,exports=this.exports,require=this.require.bind(this);");
   duk_dup(ctx, 0);
   duk_push_string(ctx, "}");
   duk_concat(ctx, 3);
+  duk_insert(ctx, -2);
 
   // Compile to a function
-  duk_get_prop_string(ctx, 0, "id");
   duk_compile(ctx, DUK_COMPILE_FUNCTION);
+
   duk_push_this(ctx);
   duk_call_method(ctx, 0);
 


### PR DESCRIPTION
use correct id as file name before call duk_compile.
it could help user to locate the error during debug.
e.g test.js like
```javascript
print('test');

a.b = c;
```
before apply this patch, it just show following error
ReferenceError: identifier 'a' undefined
	duk_js_var.c:1235
after apply this patch, it will show  $filename and $linenumber
... ...dukluv/test.js:3 preventsyield 