### PR TITLE
fix fs write issue

### DIFF
--- a/src/duv.h
+++ b/src/duv.h
@@ -61,6 +61,7 @@ typedef struct {
   int req_ref; // ref for uv_req_t's userdata
   int context;
   int callback_ref; // ref for callback
+  int data_ref;
   void* data; // extra data
 } duv_req_t;
 

--- a/src/fs.c
+++ b/src/fs.c
@@ -241,6 +241,8 @@ duk_ret_t duv_fs_write(duk_context *ctx) {
   uv_file file;
   uv_buf_t buf;
   int64_t offset;
+  duv_req_t *data;
+  uv_fs_t* req;
 
   dschema_check(ctx, (const duv_schema_entry[]){
     {"fd", duv_is_fd},
@@ -254,9 +256,12 @@ duk_ret_t duv_fs_write(duk_context *ctx) {
   duv_get_data(ctx, 1, &buf);
   offset = duk_get_number(ctx, 2);
 
-  uv_fs_t* req;
   req = duk_push_fixed_buffer(ctx, sizeof(*req));
-  req->data = duv_setup_req(ctx, 3);
+  data = duv_setup_req(ctx, 3);
+  duk_dup(ctx, 1);
+  data->data_ref = duv_ref(ctx);
+
+  req->data = data;
   req->ptr = buf.base;
   FS_CALL(write, req, file, &buf, 1, offset);
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -40,6 +40,7 @@ duv_req_t* duv_setup_req(duk_context *ctx, int callback_index) {
   else {
     data->callback_ref = 0;
   }
+  data->data_ref = 0;
   data->data = NULL;
   return data;
 }
@@ -48,6 +49,7 @@ duv_req_t* duv_cleanup_req(duk_context *ctx, duv_req_t *data) {
   duv_unref(ctx, data->req_ref);
   duv_unref(ctx, data->context);
   duv_unref(ctx, data->callback_ref);
+  duv_unref(ctx, data->data_ref);
   duk_free(ctx, data->data);
   duk_free(ctx, data);
   return NULL;


### PR DESCRIPTION
run dukluv with test.js,.e.g ./dukluv test.js
```javascript
var fd = uv.fs_open('uv_write.test', 'w', parseInt('0666', 8));

uv.fs_write(fd, Duktape.Buffer('abcdefg'), 0, function(){
        uv.fs_close(fd);
});
```
uv_write.test content maybe random value, for the Duktape.Buffer('abcdefg') may already be released in asynchronous setup.

add `data_ref` field in `struct duv_req_t` to ref to data passed from JS side
Signed-off-by: Jie Yang <topelinux@gmail.com>