### PR TITLE
Add argv binding

### DIFF
--- a/src/duv.c
+++ b/src/duv.c
@@ -121,6 +121,7 @@ static const duk_function_list_entry duv_funcs[] = {
   {"hrtime", duv_hrtime, 0},
   {"update_time", duv_update_time, 0},
   {"now", duv_now, 0},
+  {"argv", duv_argv, 0},
 
   // miniz.c
   {"inflate", duv_tinfl, 2},

--- a/src/main.c
+++ b/src/main.c
@@ -447,6 +447,34 @@ static duk_ret_t duv_main(duk_context *ctx) {
   return 0;
 }
 
+static duk_ret_t duv_stash_argv(duk_context *ctx) {
+  char **argv = (char **) duk_require_pointer(ctx, 0);
+  int argc = (int) duk_require_int(ctx, 1);
+  int i;
+
+  duk_push_global_stash(ctx);
+  duk_push_array(ctx);
+  for (i = 0; i < argc; i++) {
+    duk_push_string(ctx, argv[i]);
+    duk_put_prop_index(ctx, -2, i);
+  }
+  duk_put_prop_string(ctx, -2, "argv");
+  duk_pop(ctx);
+  return 0;
+}
+
+static void duv_dump_error(duk_context *ctx, duk_idx_t idx) {
+  fprintf(stderr, "\nUncaught Exception:\n");
+  if (duk_is_object(ctx, idx)) {
+    duk_get_prop_string(ctx, -1, "stack");
+    fprintf(stderr, "\n%s\n\n", duk_get_string(ctx, -1));
+    duk_pop(ctx);
+  }
+  else {
+    fprintf(stderr, "\nThrown Value: %s\n\n", duk_json_encode(ctx, idx));
+  }
+}
+
 int main(int argc, char *argv[]) {
   duk_context *ctx = NULL;
   uv_loop_init(&loop);
@@ -466,18 +494,21 @@ int main(int argc, char *argv[]) {
   }
   loop.data = ctx;
 
+  // Stash argv for later access
+  duk_push_pointer(ctx, (void *) argv);
+  duk_push_int(ctx, argc);
+  if (duk_safe_call(ctx, duv_stash_argv, 2, 1)) {
+    duv_dump_error(ctx, -1);
+    uv_loop_close(&loop);
+    duk_destroy_heap(ctx);
+    return 1;
+  }
+  duk_pop(ctx);
+
   duk_push_c_function(ctx, duv_main, 1);
   duk_push_string(ctx, argv[1]);
   if (duk_pcall(ctx, 1)) {
-    fprintf(stderr, "\nUncaught Exception:\n");
-    if (duk_is_object(ctx, -1)) {
-      duk_get_prop_string(ctx, -1, "stack");
-      fprintf(stderr, "\n%s\n\n", duk_get_string(ctx, -1));
-      duk_pop(ctx);
-    }
-    else {
-      fprintf(stderr, "\nThrown Value: %s\n\n", duk_json_encode(ctx, -1));
-    }
+    duv_dump_error(ctx, -1);
     uv_loop_close(&loop);
     duk_destroy_heap(ctx);
     return 1;

--- a/src/misc.c
+++ b/src/misc.c
@@ -272,3 +272,9 @@ duk_ret_t duv_now(duk_context *ctx) {
   duk_push_uint(ctx, now);
   return 1;
 }
+
+duk_ret_t duv_argv(duk_context *ctx) {
+  duk_push_global_stash(ctx);
+  duk_get_prop_string(ctx, -1, "argv");
+  return 1;
+}

--- a/src/misc.h
+++ b/src/misc.h
@@ -21,5 +21,6 @@ duk_ret_t duv_get_total_memory(duk_context *ctx);
 duk_ret_t duv_hrtime(duk_context *ctx);
 duk_ret_t duv_update_time(duk_context *ctx);
 duk_ret_t duv_now(duk_context *ctx);
+duk_ret_t duv_argv(duk_context *ctx);
 
 #endif

--- a/test-argv.js
+++ b/test-argv.js
@@ -1,0 +1,6 @@
+"use strict";
+
+// uv.argv() returns the C argv[] array
+uv.argv().forEach(function (v, i) {
+  print('arg', i, v);
+});


### PR DESCRIPTION
Add `uv.argv()` which returns an Array containing the full C `argv[]` without modifications.

The returned array is not a copy so edits made to the array are visible in a future `uv.argv()` call.