### PR TITLE
Fix syntax error when compiling dukluv on MSVC 2015

### DIFF
--- a/src/duv.h
+++ b/src/duv.h
@@ -9,7 +9,11 @@
 #include <unistd.h>
 #endif
 
+#if _MSC_VER >= 1800
+#include <stdbool.h>
+#else
 typedef enum { false, true } bool;
+#endif
 
 #if defined(_WIN32)
 # include <fcntl.h>


### PR DESCRIPTION
MSVC 2013+ and most current versions of GCC include stdbool.h, so prefer that.